### PR TITLE
Fix encoder by emitting all layers and nalus

### DIFF
--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -15,8 +15,9 @@ repository = "https://github.com/ralfbiedert/openh264-rust"
 [features]
 default = ["decoder", "encoder"]
 decoder = ["openh264-sys2/decoder"]
-encoder = ["openh264-sys2/encoder"]
+encoder = ["smallvec", "openh264-sys2/encoder"]
 backtrace = []
 
 [dependencies]
 openh264-sys2 = { path = "../openh264-sys2", version = "0.1", default-features = false }
+smallvec = { version = "1.6", optional = true }


### PR DESCRIPTION
Add the missing data to properly write an h.265 stream, this include the sps/dps NAL units.
The current implementation exposes the individual NAL units as it makes it easier to write them to an mp4 file.