### PR TITLE
Asm support

### DIFF
--- a/openh264-sys2/Cargo.toml
+++ b/openh264-sys2/Cargo.toml
@@ -16,10 +16,10 @@ license = "BSD-2-Clause"
 default = ["decoder", "encoder"]
 decoder = []
 encoder = []
-asm = []
+asm = ["nasm-rs"]
 #static_cpp = []
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-nasm-rs = { version = "0.2", features = ["parallel"] }
 walkdir = "2.3"
+nasm-rs = { version = "0.2", features = ["parallel"], optional = true }

--- a/openh264-sys2/Cargo.toml
+++ b/openh264-sys2/Cargo.toml
@@ -16,8 +16,10 @@ license = "BSD-2-Clause"
 default = ["decoder", "encoder"]
 decoder = []
 encoder = []
+asm = []
 #static_cpp = []
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
+nasm-rs = { version = "0.2", features = ["parallel"] }
 walkdir = "2.3"

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -11,7 +11,7 @@ fn ugly_import<P: AsRef<Path>>(x: P, extenstion: &str, exclude: &str) -> Vec<Str
         .collect()
 }
 
-fn build_library(name: &str, root: &str, extra_inclues: &[&str]) {
+fn build_lib(name: &str, root: &str, includes: &[&str]) {
     let mut debug = false;
     let mut opt_level = 3;
 
@@ -37,7 +37,7 @@ fn build_library(name: &str, root: &str, extra_inclues: &[&str]) {
         .flag_if_supported("-undefined dynamic_lookup")
         .debug(debug);
 
-    for include in extra_inclues {
+    for include in includes {
         cc_build.include(include);
     }
 
@@ -105,24 +105,24 @@ fn build_library(name: &str, root: &str, extra_inclues: &[&str]) {
 }
 
 fn main() {
-    build_library("common", "upstream/codec/common", &[]);
+    build_lib("common", "upstream/codec/common", &[]);
+    build_lib(
+        "processing",
+        "upstream/codec/processing",
+        &[
+            "upstream/codec/processing/src/common/",
+            "upstream/codec/processing/interface/",
+        ],
+    );
     if cfg!(feature = "decoder") {
-        build_library(
+        build_lib(
             "decoder",
             "upstream/codec/decoder",
             &["upstream/codec/decoder/core/inc/", "upstream/codec/decoder/plus/inc/"],
         );
     }
     if cfg!(feature = "encoder") {
-        build_library(
-            "processing",
-            "upstream/codec/processing",
-            &[
-                "upstream/codec/processing/src/common/",
-                "upstream/codec/processing/interface/",
-            ],
-        );
-        build_library(
+        build_lib(
             "encoder",
             "upstream/codec/encoder",
             &[
@@ -131,5 +131,8 @@ fn main() {
                 "upstream/codec/processing/interface/",
             ],
         );
+    }
+    if !cfg!(feature = "decoder") && !cfg!(feature = "encoder") {
+        panic!("at least one of 'decoder' or 'encoder' feature must be enabled");
     }
 }

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -1,17 +1,17 @@
+use std::path::Path;
 use walkdir::WalkDir;
 
-fn ugly_cpp_import(x: &str) -> Vec<String> {
+fn ugly_import<P: AsRef<Path>>(x: P, extenstion: &str, exclude: &str) -> Vec<String> {
     WalkDir::new(x)
         .into_iter()
         .map(|x| x.unwrap())
-        .filter(|x| x.path().to_str().unwrap().ends_with("cpp"))
+        .filter(|x| x.path().to_str().unwrap().ends_with(extenstion))
         .map(|x| x.path().to_str().unwrap().to_string())
-        // Otherwise fails when compiling on Linux
-        .filter(|x| !x.contains("DllEntry.cpp"))
+        .filter(|x| !x.contains(exclude))
         .collect()
 }
 
-fn main() {
+fn build_library(name: &str, root: &str, extra_inclues: &[&str]) {
     let mut debug = false;
     let mut opt_level = 3;
 
@@ -19,55 +19,117 @@ fn main() {
         debug = true;
         opt_level = 0;
     }
-    if cfg!(feature = "decoder") {
-        cc::Build::new()
-            .include("upstream/codec/api/svc/")
-            .include("upstream/codec/common/inc/")
-            .include("upstream/codec/decoder/core/inc/")
-            .include("upstream/codec/decoder/plus/inc/")
-            .include("upstream/codec/processing/interface/")
-            .files(ugly_cpp_import("upstream/codec/common"))
-            .files(ugly_cpp_import("upstream/codec/decoder"))
-            .cpp(true)
-            .warnings(false)
-            .opt_level(opt_level)
-            .pic(true)
-            // Upstream sets these two and if we don't we get segmentation faults on Linux and MacOS ... Happy times.
-            .flag_if_supported("-fno-strict-aliasing")
-            .flag_if_supported("-fstack-protector-all")
-            .flag_if_supported("-fembed-bitcode")
-            .flag_if_supported("-fno-common")
-            .flag_if_supported("-undefined dynamic_lookup")
-            .debug(debug)
-            .compile("libopenh264_decode.a");
 
-        println!("cargo:rustc-link-lib=static=openh264_decode");
+    let mut cc_build = cc::Build::new();
+    cc_build
+        .include("upstream/codec/api/svc/")
+        .include("upstream/codec/common/inc/")
+        .cpp(true)
+        .warnings(false)
+        .opt_level(opt_level)
+        .files(ugly_import(root, "cpp", "DllEntry.cpp")) // Otherwise fails when compiling on Linux
+        .pic(true)
+        // Upstream sets these two and if we don't we get segmentation faults on Linux and MacOS ... Happy times.
+        .flag_if_supported("-fno-strict-aliasing")
+        .flag_if_supported("-fstack-protector-all")
+        .flag_if_supported("-fembed-bitcode")
+        .flag_if_supported("-fno-common")
+        .flag_if_supported("-undefined dynamic_lookup")
+        .debug(debug);
+
+    for include in extra_inclues {
+        cc_build.include(include);
     }
 
-    if cfg!(feature = "encoder") {
-        cc::Build::new()
-            .include("upstream/codec/api/svc/")
-            .include("upstream/codec/common/inc/")
-            .include("upstream/codec/encoder/core/inc/")
-            .include("upstream/codec/encoder/plus/inc/")
-            .include("upstream/codec/processing/interface/")
-            .include("upstream/codec/processing/src/common/")
-            .files(ugly_cpp_import("upstream/codec/encoder"))
-            .files(ugly_cpp_import("upstream/codec/processing"))
-            .cpp(true)
-            .warnings(false)
-            .opt_level(opt_level)
-            .pic(true)
-            // Upstream sets these two and if we don't we get segmentation faults on Linux and MacOS ... Happy times.
-            .flag_if_supported("-fno-strict-aliasing")
-            .flag_if_supported("-fstack-protector-all")
-            .flag_if_supported("-fembed-bitcode")
-            .flag_if_supported("-fno-common")
-            .flag_if_supported("-undefined dynamic_lookup")
-            .debug(debug)
-            // .cpp_link_stdlib("c++_static")
-            .compile("libopenh264_encode.a");
+    if cfg!(feature = "asm") {
+        let target = std::env::var("TARGET").unwrap();
 
-        println!("cargo:rustc-link-lib=static=openh264_encode");
+        let is_64bits = target.starts_with("x86_64") || target.starts_with("aarch64");
+        let is_x86 = target.starts_with("x86_64") || target.starts_with("i686");
+        let is_arm = target.starts_with("arm") || target.starts_with("arm7") || target.starts_with("aarch64");
+        let is_windows = target.contains("windows");
+        let is_unix = target.contains("apple") || target.contains("linux");
+
+        let (extension, cpp_define, asm_dir, asm_define, exclude) = if is_x86 {
+            let extension = ".asm";
+            let cpp_define = "X86_ASM";
+            let asm_dir = "x86";
+            let exclusion = "asm_inc.asm";
+            if is_windows && is_64bits {
+                (extension, cpp_define, asm_dir, "WIN64", exclusion)
+            } else if is_unix && is_64bits {
+                (extension, cpp_define, asm_dir, "UNIX64", exclusion)
+            } else {
+                (extension, cpp_define, asm_dir, "X86_32", exclusion)
+            }
+        } else if is_arm {
+            let extension = ".S";
+            if is_64bits {
+                (
+                    extension,
+                    "HAVE_NEON_AARCH64",
+                    "arm64",
+                    "HAVE_NEON_AARCH64",
+                    "arm_arch64_common_macro.S",
+                )
+            } else {
+                (extension, "HAVE_NEON", "arm", "HAVE_NEON", "arm_arch_common_macro.S")
+            }
+        } else {
+            panic!("");
+        };
+
+        cc_build.define(cpp_define, None);
+
+        if is_x86 {
+            let objs = nasm_rs::Build::new()
+                .include(format!("upstream/codec/common/{}/", asm_dir))
+                .define(asm_define, None)
+                .files(ugly_import(root, extension, exclude))
+                .compile_objects()
+                .unwrap();
+            for obj in &objs {
+                cc_build.object(obj);
+            }
+        } else {
+            cc_build
+                .include(format!("upstream/codec/common/{}/", asm_dir))
+                .define(asm_define, None)
+                .files(ugly_import(root, extension, exclude));
+        }
+    }
+
+    cc_build.compile(format!("libopenh264_{}.a", name).as_str());
+
+    println!("cargo:rustc-link-lib=static=openh264_{}", name);
+}
+
+fn main() {
+    build_library("common", "upstream/codec/common", &[]);
+    if cfg!(feature = "decoder") {
+        build_library(
+            "decoder",
+            "upstream/codec/decoder",
+            &["upstream/codec/decoder/core/inc/", "upstream/codec/decoder/plus/inc/"],
+        );
+    }
+    if cfg!(feature = "encoder") {
+        build_library(
+            "processing",
+            "upstream/codec/processing",
+            &[
+                "upstream/codec/processing/src/common/",
+                "upstream/codec/processing/interface/",
+            ],
+        );
+        build_library(
+            "encoder",
+            "upstream/codec/encoder",
+            &[
+                "upstream/codec/encoder/core/inc/",
+                "upstream/codec/encoder/plus/inc/",
+                "upstream/codec/processing/interface/",
+            ],
+        );
     }
 }

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -42,7 +42,8 @@ fn add_openh264_lib(name: &str, root: &str, includes: &[&str]) {
         cc_build.include(include);
     }
 
-    if cfg!(feature = "asm") {
+    #[cfg(feature = "asm")]
+    {
         let target = std::env::var("TARGET").unwrap();
 
         let is_64bits = target.starts_with("x86_64") || target.starts_with("aarch64");
@@ -119,25 +120,25 @@ fn main() {
             "upstream/codec/processing/interface/",
         ],
     );
-    if cfg!(feature = "decoder") {
-        add_openh264_lib(
-            "decoder",
-            "upstream/codec/decoder",
-            &["upstream/codec/decoder/core/inc/", "upstream/codec/decoder/plus/inc/"],
-        );
-    }
-    if cfg!(feature = "encoder") {
-        add_openh264_lib(
-            "encoder",
-            "upstream/codec/encoder",
-            &[
-                "upstream/codec/encoder/core/inc/",
-                "upstream/codec/encoder/plus/inc/",
-                "upstream/codec/processing/interface/",
-            ],
-        );
-    }
-    if !cfg!(feature = "decoder") && !cfg!(feature = "encoder") {
-        panic!("at least one of 'decoder' or 'encoder' feature must be enabled");
-    }
+
+    #[cfg(feature = "decoder")]
+    add_openh264_lib(
+        "decoder",
+        "upstream/codec/decoder",
+        &["upstream/codec/decoder/core/inc/", "upstream/codec/decoder/plus/inc/"],
+    );
+
+    #[cfg(feature = "encoder")]
+    add_openh264_lib(
+        "encoder",
+        "upstream/codec/encoder",
+        &[
+            "upstream/codec/encoder/core/inc/",
+            "upstream/codec/encoder/plus/inc/",
+            "upstream/codec/processing/interface/",
+        ],
+    );
+
+    #[cfg(not(any(feature = "decoder", feature = "encoder")))]
+    panic!("at least one of 'decoder' or 'encoder' feature must be enabled");
 }

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use walkdir::WalkDir;
 
 // if this gets more complicated, we might want to inline the list of files available in meson
-fn glob_import<P: AsRef<Path>>(x: P, extenstion: &str, exclude: &str) -> Vec<String> {
-    WalkDir::new(x)
+fn glob_import<P: AsRef<Path>>(root: P, extenstion: &str, exclude: &str) -> Vec<String> {
+    WalkDir::new(root)
         .into_iter()
         .map(|x| x.unwrap())
         .filter(|x| x.path().to_str().unwrap().ends_with(extenstion))

--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/ralfbiedert/openh264-rust"
 default = ["decoder", "encoder"]
 decoder = ["openh264-sys2/decoder"]
 encoder = ["openh264-sys2/encoder"]
+asm = ["openh264-sys2/asm"]
 backtrace = []
 
 [dependencies]


### PR DESCRIPTION
Adding assembly support for openh264-sys2 by relying on nasm-rs on x86/x86_64.
Currently if nasm is missing we do not fail the build, we issue a warning, (I had an error originally but though that might be enough if the feature is enabled by default).
The feature is not enabled by default.

Here are the bench results on my machine (11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz   2.61 GHz):
```
test decode_yuv_multi_512x512        ... bench:   7,725,449 ns/iter (+/- 798,862)
test decode_yuv_single_1920x1080     ... bench:   8,218,159 ns/iter (+/- 427,824)
test decode_yuv_single_512x512_cabac ... bench:   1,509,231 ns/iter (+/- 54,221)
test decode_yuv_single_512x512_cavlc ... bench:   1,708,157 ns/iter (+/- 29,290)
test whole_decoder                   ... bench:   1,878,174 ns/iter (+/- 32,181)

test encode_1920x1080_from_yuv       ... bench:  26,635,666 ns/iter (+/- 557,558)
test encode_512x512_from_yuv         ... bench:   3,486,324 ns/iter (+/- 156,321)
```

with the feature enabled

```
test decode_yuv_multi_512x512        ... bench:   3,715,871 ns/iter (+/- 121,538)
test decode_yuv_single_1920x1080     ... bench:   3,764,356 ns/iter (+/- 427,062)
test decode_yuv_single_512x512_cabac ... bench:     794,165 ns/iter (+/- 56,266)
test decode_yuv_single_512x512_cavlc ... bench:   1,267,514 ns/iter (+/- 48,114)
est whole_decoder                    ... bench:   1,490,782 ns/iter (+/- 131,085)

test encode_1920x1080_from_yuv       ... bench:  10,338,088 ns/iter (+/- 1,085,816)
test encode_512x512_from_yuv         ... bench:   1,333,494 ns/iter (+/- 29,557)
```

Note that I only tested the following targets: `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu`.
