### PR TITLE
add EncoderConfig::rate_control_mode

### DIFF
--- a/openh264/src/encoder.rs
+++ b/openh264/src/encoder.rs
@@ -84,11 +84,17 @@ impl Drop for EncoderRawAPI {
 /// Specifies the mode used by the encoder to control the rate.
 #[derive(Copy, Clone, Debug)]
 pub enum RateControlMode {
+    /// quality mode
     Quality,
+    /// bitrate mode
     Bitrate,
+    /// no bitrate control, only using buffer status, adjust the video quality
     Bufferbased,
+    /// rate control based timestamp
     Timestamp,
+    /// this is in-building RC MODE, WILL BE DELETED after algorithm tuning!
     BitrateModePostSkip,
+    /// rate control off mode
     Off,
 }
 


### PR DESCRIPTION
This adds `add EncoderConfig::rate_control_mode`.

I'm not entirely sure about the default value for `RateControlMode`. I made a runtime check of the value of `params.iRCMode` after `raw_api.get_default_params(&mut params).ok()?;` in `Encoder::with_config` and it was 0. This corresponds to `RateControlMode::Quality`, so this is the value I used in the implementation of `Default` for `RateControlMode`.

After merging this, I would be grateful if you would publish a new release. Thanks again!