### PR TITLE
Rework the build system, support more systems

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 #[build]
 #rustflags = ["-C", "link-args=-fsanitize=address"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,9 @@ jobs:
         toolchain:
           - stable
           - nightly
+        nasm:
+          - true
+          - false
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2
@@ -31,6 +34,11 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.toolchain }}
         override: true
+    - name: Install NASM
+      uses: ilammy/setup-nasm@v1
+      if: matrix.nasm
+      with:
+        version: 2.15.05
     - name: LFS Checkout
       run: git lfs checkout
     - name: Version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, windows-latest, macos-latest]
-        toolchain:
-          - stable
-          - nightly
-        nasm:
-          - true
-          - false
+        nasm: [nasm, no-nasm]
+        target:
+          - i686-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+          # eh, actually it doesn't seem easy to get musl working
+          # because openh265 requires a C++ compiler, and musl doesn't provide one
+#          - x86_64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - i686-pc-windows-msvc
+          - i686-pc-windows-gnu
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+        include:
+          - target: i686-unknown-linux-gnu
+            runs-on: ubuntu-latest
+            packages: gcc-multilib g++-multilib # provides 32-bit headers
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+
+#          - target: x86_64-unknown-linux-musl
+#            runs-on: ubuntu-latest
+#            packages: musl-tools # provides musl-gcc
+
+          - target: x86_64-apple-darwin
+            runs-on: macos-latest
+
+          - target: i686-pc-windows-gnu
+            runs-on: windows-latest
+            mingw: x86
+          - target: i686-pc-windows-msvc
+            runs-on: windows-latest
+          - target: x86_64-pc-windows-gnu
+            runs-on: windows-latest
+            mingw: x64
+          - target: x86_64-pc-windows-msvc
+            runs-on: windows-latest
+
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2
@@ -32,18 +62,30 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: ${{ matrix.toolchain }}
+        toolchain: stable
         override: true
+        target: ${{ matrix.target }}
     - name: Install NASM
       uses: ilammy/setup-nasm@v1
-      if: matrix.nasm
+      if: matrix.nasm == 'nasm'
       with:
         version: 2.15.05
+    - name: Install Additional packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.2.4
+      if: matrix.packages != ''
+      with:
+        packages: ${{ matrix.packages }}
+        version: 1.0
+    - name: Set up MinGW
+      uses: egor-tensin/setup-mingw@v2
+      if: matrix.mingw != ''
+      with:
+        platform: ${{ matrix.mingw }}
     - name: LFS Checkout
       run: git lfs checkout
     - name: Version
       run: rustc -Vv
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --target=${{ matrix.target }}
     - name: Test
-      run: cargo test --verbose -- --test-threads=1 --nocapture
+      run: cargo test --verbose --target=${{ matrix.target }} -- --test-threads=1 --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Version
       run: rustc -Vv
     - name: Build
-      run: cargo build --verbose --target=${{ matrix.target }}
+      run: cargo build --verbose --target=${{ matrix.target }} --tests
     - name: Test
       run: cargo test --verbose --target=${{ matrix.target }} -- --test-threads=1 --nocapture
-      if: matrix.no-test != 'true'
+      if: matrix.no-test != true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,17 +22,29 @@ jobs:
           # eh, actually it doesn't seem easy to get musl working
           # because openh265 requires a C++ compiler, and musl doesn't provide one
 #          - x86_64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
           - i686-pc-windows-msvc
           - i686-pc-windows-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
         include:
           - target: i686-unknown-linux-gnu
             runs-on: ubuntu-latest
             packages: gcc-multilib g++-multilib # provides 32-bit headers
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
+            runs-on: ubuntu-latest
+            packages: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf # provides armv7 headers
+            no-test: true
+          - target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+            packages: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu # provides aarch64 headers
+            no-test: true
 
 #          - target: x86_64-unknown-linux-musl
 #            runs-on: ubuntu-latest
@@ -40,6 +52,9 @@ jobs:
 
           - target: x86_64-apple-darwin
             runs-on: macos-latest
+          - target: aarch64-apple-darwin
+            runs-on: macos-latest
+            no-test: true
 
           - target: i686-pc-windows-gnu
             runs-on: windows-latest
@@ -51,6 +66,9 @@ jobs:
             mingw: x64
           - target: x86_64-pc-windows-msvc
             runs-on: windows-latest
+          - target: aarch64-pc-windows-msvc
+            runs-on: windows-latest
+            no-test: true
 
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -89,3 +107,4 @@ jobs:
       run: cargo build --verbose --target=${{ matrix.target }}
     - name: Test
       run: cargo test --verbose --target=${{ matrix.target }} -- --test-threads=1 --nocapture
+      if: matrix.no-test != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         lfs: true
-    - name: Install latest Rust Nightly
+    - name: Install Rust toolchain
       id: actions-rs
       uses: actions-rs/toolchain@v1
       with:

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -17,6 +17,195 @@ fn glob_import<P: AsRef<Path>>(root: P, extenstion: &str, exclude: &str) -> Vec<
         .collect()
 }
 
+#[derive(Debug, Copy, Clone)]
+enum TargetFamily {
+    Unix,
+    Windows,
+    Wasm,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetOs {
+    Windows,
+    Macos,
+    Ios,
+    Linux,
+    Android,
+    Freebsd,
+    Dragonfly,
+    Openbsd,
+    Netbsd,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetArch {
+    X86,
+    X86_64,
+    Arm,
+    Aarch64,
+    Mips,
+    Powerpc,
+    Powerpc64,
+    S390x,
+    Wasm32,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetEnv {
+    NoEnv,
+    Gnu,
+    Msvc,
+    Musl,
+    Sgx,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct Target {
+    family: TargetFamily,
+    os: TargetOs,
+    arch: TargetArch,
+    env: TargetEnv,
+}
+
+impl Target {
+    fn from_env() -> Self {
+        let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+        let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+        let family = match family.as_str() {
+            "unix" => TargetFamily::Unix,
+            "windows" => TargetFamily::Windows,
+            "wasm" => TargetFamily::Wasm,
+            _ => panic!("Unknown target family: {}", family),
+        };
+        let os = match os.as_str() {
+            "windows" => TargetOs::Windows,
+            "macos" => TargetOs::Macos,
+            "ios" => TargetOs::Ios,
+            "linux" => TargetOs::Linux,
+            "android" => TargetOs::Android,
+            "freebsd" => TargetOs::Freebsd,
+            "dragonfly" => TargetOs::Dragonfly,
+            "openbsd" => TargetOs::Openbsd,
+            "netbsd" => TargetOs::Netbsd,
+            _ => panic!("Unknown target os: {}", os),
+        };
+        let arch = match arch.as_str() {
+            "x86" => TargetArch::X86,
+            "x86_64" => TargetArch::X86_64,
+            "arm" => TargetArch::Arm,
+            "aarch64" => TargetArch::Aarch64,
+            "mips" => TargetArch::Mips,
+            "powerpc" => TargetArch::Powerpc,
+            "powerpc64" => TargetArch::Powerpc64,
+            "s390x" => TargetArch::S390x,
+            "wasm32" => TargetArch::Wasm32,
+            _ => panic!("Unknown target arch: {}", arch),
+        };
+        let env = match env.as_str() {
+            "" => TargetEnv::NoEnv,
+            "gnu" => TargetEnv::Gnu,
+            "msvc" => TargetEnv::Msvc,
+            "musl" => TargetEnv::Musl,
+            "sgx" => TargetEnv::Sgx,
+            _ => panic!("Unknown target env: {}", env),
+        };
+
+        Self {
+            family,
+            os,
+            arch,
+            env,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NasmConfiguration {
+    /// Extension for assembly files
+    asm_extension: String,
+    /// Directory to add to asm include path
+    include_dir: String,
+    /// Exclude asm files from compilation
+    /// Used to prevent compilation of assembly files included by other assembly files
+    asm_exclude: String,
+    /// A C++ define used to identify the assembly platform
+    cpp_define: String,
+    /// An assembly define used to select sub-platforms
+    asm_platform_define: String,
+    /// Whether to prefix symbols with an underscore
+    prefix_symbols: bool,
+}
+
+impl NasmConfiguration {
+    fn find(target: Target) -> Option<Self> {
+        use TargetFamily::*;
+        use TargetArch::*;
+        // use TargetEnv::*;
+        use TargetOs::*;
+
+        let asm_extension = match target.arch {
+            X86_64 | X86 => ".asm",
+            Aarch64 | Arm => ".S",
+            _ => return None,
+        };
+
+        let asm_dir = match target.arch {
+            X86_64 | X86 => "x86",
+            Aarch64 => "arm64",
+            Arm => "arm",
+            _ => return None,
+        };
+
+        let asm_exclude = match target.arch {
+            X86_64 | X86 => "asm_inc.asm",
+            Aarch64 => "arm_arch64_common_macro.S",
+            Arm => "arm_arch_common_macro.S",
+            _ => return None,
+        };
+
+        // CPP defines to inform which assembly symbols to use.
+        let cpp_define = match target.arch {
+            X86_64 | X86 => "X86_ASM",
+            Aarch64 => "HAVE_NEON_AARCH64",
+            Arm => "HAVE_NEON",
+            _ => return None,
+        };
+
+        // A special define needed for some platforms.
+        let asm_platform_define = match target.arch {
+            X86_64 => match target.family {
+                Unix => "UNIX64",
+                TargetFamily::Windows => "WIN64",
+                _ => return None,
+            },
+            X86 => "X86_32",
+            Aarch64 => "HAVE_NEON_AARCH64",
+            Arm => "HAVE_NEON",
+            _ => return None,
+        };
+
+        // Prefix symbols exported from assembly with an underscore on x86/x86_64 macOS and x86 Windows.
+        let prefix_underscores = matches!(target, Target {
+            os: Macos,
+            arch: X86_64 | X86,
+            ..
+        } | Target {
+            os: TargetOs::Windows,
+            arch: X86,
+            ..
+        });
+
+        Some(Self {
+            asm_extension: asm_extension.to_string(),
+            include_dir: asm_dir.to_string(),
+            asm_exclude: asm_exclude.to_string(),
+            cpp_define: cpp_define.to_string(),
+            asm_platform_define: asm_platform_define.to_string(),
+            prefix_symbols: prefix_underscores,
+        })
+    }
+}
+
 /// Attempts to compile assembly units and links them to the current compilation build.
 ///
 /// Ok, I tried to clean this up for 0.3 since I found the previous build logic a bit hard to follow. This works for me,
@@ -25,74 +214,37 @@ fn glob_import<P: AsRef<Path>>(root: P, extenstion: &str, exclude: &str) -> Vec<
 /// Feel free to submit PRs improving this file, but try to keep the logic 'KISS' and minimize branches and nesting if possible.
 #[allow(unused)]
 fn try_compile_nasm(cc_build_command: &mut Build, root: &str) {
-    // If NASM isn't found we don't use it
-    // if Command::new("nasm").status().is_err() {
-    //     println!("Command `nasm` not found, things will be slower.");
-    //     return;
-    // }
-
-    let target = std::env::var("TARGET").unwrap();
-
-    let is_64bits = target.starts_with("x86_64") || target.starts_with("aarch64");
-    let is_x86 = target.starts_with("x86_64") || target.starts_with("i686");
-    let is_arm = target.starts_with("arm") || target.starts_with("arm7") || target.starts_with("aarch64");
-    let is_windows = target.contains("windows");
-    let is_unix = target.contains("apple") || target.contains("linux");
-
-    // `_UNUSED` is just a define that doesn't interfere with any actual define in OpenH264.
-    let mut define_cpp = "_UNUSED";
-    let mut define_asm = "_UNUSED";
-    let mut define_prefix = "_UNUSED";
-    let mut asm_dir = "";
-    let mut extension = "";
-    let mut exclusion = "";
-
-    if is_x86 {
-        extension = ".asm";
-        define_cpp = "X86_ASM";
-        asm_dir = "x86";
-        exclusion = "asm_inc.asm";
-
-        if is_windows && is_64bits {
-            define_asm = "WIN64";
-        } else if is_unix && is_64bits {
-            define_asm = "UNIX64";
-            define_prefix = "PREFIX";
-        } else {
-            define_asm = "X86_32";
-        }
-    } else if is_arm {
-        extension = ".S";
-
-        if is_64bits {
-            define_cpp = "HAVE_NEON_AARCH64";
-            asm_dir = "arm64";
-            define_asm = "HAVE_NEON_AARCH64";
-            exclusion = "arm_arch64_common_macro.S";
-        } else {
-            define_cpp = "HAVE_NEON";
-            asm_dir = "arm";
-            define_asm = "HAVE_NEON";
-            exclusion = "arm_arch_common_macro.S";
-        }
+    if std::env::var("OPENH264_NO_ASM").is_ok() {
+        println!("NASM compilation disabled by environment variable.");
+        return;
     }
+
+    let target = Target::from_env();
+
+    let Some(config) = NasmConfiguration::find(target) else {
+        println!("No NASM configuration found for target, not using any assembly.\nTarget: {:?}", target);
+        return;
+    };
 
     // Try to compile NASM targets
     let mut nasm_build = nasm_rs::Build::new();
     let mut nasm_build = nasm_build
-        .include(format!("upstream/codec/common/{}/", asm_dir))
-        .define(define_asm, Some(define_asm))
-        .define(define_prefix, None);
+        .include(format!("upstream/codec/common/{}/", config.include_dir));
+    nasm_build = nasm_build.define(&config.asm_platform_define, None);
+    if config.prefix_symbols {
+        nasm_build = nasm_build.define("PREFIX", None);
+    }
 
     // Run `nasm` and store result.
-    let Ok(object_files) = nasm_build.files(glob_import(root, extension, exclusion)).compile_objects() else {
+    let Ok(object_files) = nasm_build.files(glob_import(root, &config.asm_extension, &config.asm_exclude)).compile_objects() else {
+        println!("Failed to compile NASM files, not using any assembly.");
         return;
     };
 
     // This here only _EXTENDS_ the build command we got passed, it doesn't
     // _RUN_ any build command on its own (we still invoked `nasm` above
     // though).
-    cc_build_command.define(define_cpp, None);
+    cc_build_command.define(&config.cpp_define, None);
 
     for object in &object_files {
         cc_build_command.object(object);
@@ -126,6 +278,17 @@ fn compile_and_add_openh264_static_lib(name: &str, root: &str, includes: &[&str]
     cc_build.compile(format!("libopenh264_{}.a", name).as_str());
 
     println!("cargo:rustc-link-lib=static=openh264_{}", name);
+
+    if let Target {
+        os: TargetOs::Windows,
+        env: TargetEnv::Gnu,
+        ..
+    } = Target::from_env() {
+        // link to libssp_nonshared.a and libssp.a on Mingw
+        // This is required for stack protectors to work on MinGW
+        println!("cargo:rustc-link-lib=static=ssp_nonshared");
+        println!("cargo:rustc-link-lib=static=ssp");
+    }
 }
 
 fn main() {

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -286,8 +286,8 @@ fn compile_and_add_openh264_static_lib(name: &str, root: &str, includes: &[&str]
     } = Target::from_env() {
         // link to libssp_nonshared.a and libssp.a on Mingw
         // This is required for stack protectors to work on MinGW
-        println!("cargo:rustc-link-lib=static=ssp_nonshared");
-        println!("cargo:rustc-link-lib=static=ssp");
+        println!("cargo:rustc-link-arg=-lssp_nonshared");
+        println!("cargo:rustc-link-arg=-lssp");
     }
 }
 


### PR DESCRIPTION
This PR (once again) reworks the way asm for different platforms is built, as well as adding more CI targets to test it.

For the environment detection I decided to use pattern matching as much as possible, as it is easier to reason about. I have also made the code explicitly bail from building asm if the platform does not seem to be supported.

As for the logic changes, I had to change this stuff:
- do the symbol underscode prefixing only on x86 windows and x86/x86_64 macOS (instead of any x86_64 unix-like os)
- do not enable stack protectors when building for windows with a MinGW toolchain. This adds a dependency on stack checking library that is not linked by rust and I could not make it link correctly otherwise (tried stuff from https://github.com/mgeier/libflac-sys/pull/29). Stack protectors are disabled on windows upstream too (see https://github.com/rdp/ffmpeg-windows-build-helpers/issues/380#issuecomment-475278667)

For the CI I changed up the matrix a bit:
- build for more rust targets, as well as combinations of "with nasm" and "without nasm"
- do not build with nightly rust. Otherwise there were just too much jobs. I believe there is not much value in testing with nightly if unstable features are not used. Breaking stable user code is not something rust does that often

Currently, all targets pass CI: https://github.com/DCNick3/openh264-rust/actions/runs/4168027112/jobs/7214327810

It would be nice to have tests covering arm platforms, and maybe even more, but github hosted runners are x86-only. There are some ways around it (like using qemu), but it didn't seem trivial, so I didn't do it.

Could use at least "it links" check though :thinking: 